### PR TITLE
7 database documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Initially the web page should only be accessible to local traffic so the data ca
 
 This document is intended to give you instructions on what you need to get this project running. For a more in depth look at the purpose, design, functionality and future improvements the wiki contains further information. 
 
-# Funcionality
+# Functionality
 
 # Requirements
 

--- a/docs/Database.md
+++ b/docs/Database.md
@@ -1,0 +1,25 @@
+# Database
+This project uses SQLite as the DBMS and in python can be accessed using the sqlite3 module.
+
+# API
+The API allows for inserting new records into the database and retrieving that data. Currently the API only supports retrieving data from the moisture_readings table. 
+
+### Constructor
+**Database(initialise=False, path=db_path, schema=schema_path)**
+
+A Database object must be created using this constructor. The arguments specify if a new database file is to be created, what path to use for the database file, and the path for a schema file to use in database construction. There are default values that set the path to "/db/database.db" and the schema path to "/db/schema.sql"
+
+
+### Methods
+
+**insert_moisture_record(timestamp, reading, location, device_id)**  
+Insert a new record into the moisture_readings table with all required fields.
+
+**get_moisture_from_timestamp(device_id, timestamp)**  
+Get a single moisture reading at a specific time.
+
+**get_all_moisture_from_device(device_id)**  
+Retrieve all moisture readings recorded from a specified device.
+
+**get_moisture_from_device_range(device, start, end)**  
+Retrieve a group of moisture readings from a specified datetime range.

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -76,7 +76,7 @@ class TestDatabase():
             location = line[2]
             device_id = line[3]
             
-            database.insert_record("moisture_readings", timestamp=timestamp, moisture=reading, location=location, device_id=device_id)
+            database._insert_record("moisture_readings", timestamp=timestamp, moisture=reading, location=location, device_id=device_id)
 
             check_record = database.get_moisture_from_timestamp(device_id, timestamp)
             assert len(check_record) == 1
@@ -85,6 +85,10 @@ class TestDatabase():
             assert f"{check_record[0]['moisture']}" == reading
             assert check_record[0]['location'] == location
             assert f"{check_record[0]['device_id']}" == device_id
+
+
+    def test_moisture_insert(self, get_test_data, setup_empty_database):
+        pass
 
 
     def test_retrieve_all_records(self, test_moisture_data, setup_dummy_database, get_test_data):

--- a/webserver/database.py
+++ b/webserver/database.py
@@ -77,7 +77,7 @@ class Database:
                 value to insert into the database.
         """
         
-        connection = self.open_standard_connection()
+        connection = self._open_standard_connection()
         cursor = connection.cursor()
 
         # Get column names from table
@@ -114,7 +114,7 @@ class Database:
             timestamp: The timestamp to use to search the database with.
         """
 
-        connection = self.open_row_connection()
+        connection = self._open_row_connection()
         cursor = connection.cursor()
         
         query = "SELECT * FROM moisture_readings WHERE device_id = (?) \
@@ -134,7 +134,7 @@ class Database:
                 retrieved.
         """
         
-        connection = self.open_row_connection()
+        connection = self._open_row_connection()
         cursor = connection.cursor()
 
         cursor.execute(f"SELECT * FROM moisture_readings WHERE device_id = (?)", (device_id,))
@@ -156,7 +156,7 @@ class Database:
                 iso date time format.
         """
         
-        connection = self.open_row_connection()
+        connection = self._open_row_connection()
         cursor = connection.cursor()
 
         query = f"SELECT * FROM moisture_readings WHERE device_id IS (?) \

--- a/webserver/database.py
+++ b/webserver/database.py
@@ -34,14 +34,15 @@ class Database:
         if initialise:
             self._create_from_schema(schema)
 
-    def open_standard_connection(self):
+
+    def _open_standard_connection(self):
         """Get a new connection to the database."""
         
         connection = sqlite3.connect(self.database)
         return connection
 
 
-    def open_row_connection(self):
+    def _open_row_connection(self):
         """Get a new connection to be used for retrieving rows from the database."""
 
         connection = sqlite3.connect(self.database)
@@ -63,7 +64,8 @@ class Database:
         connection.commit()
         connection.close()
 
-    def insert_record(self, table, **column_values):
+
+    def _insert_record(self, table, **column_values):
         """Insert a single new record into the database.
         
         This method can take an arbitrary number of column:value key pairs to 
@@ -90,6 +92,7 @@ class Database:
         connection.commit()
         connection.close()
 
+
     def insert_moisture_record(self, timestamp, reading, location, device_id):
         """Create a new record in the moisture table.
         
@@ -99,16 +102,10 @@ class Database:
             location: The name of the location where the reading was taken.
             device_id: ID number of the device that took the reading.
         """
-        connection = self.open_standard_connection()
-                
-        cur = connection.cursor()
-        cur.execute("INSERT INTO moisture_readings (timestamp, moisture, location, device_id) VALUES (?, ?, ?, ?)",
-                        (timestamp, reading, location, device_id)
-                    )
         
-        connection.commit()
-        connection.close()
-        
+        self._insert_record("moisture_readings", timestamp=timestamp, moisture=reading, location=location, device_id=device_id)
+       
+       
     def get_moisture_from_timestamp(self, device_id, timestamp):
         """Retrieve a single record based on device_id and timestamp.
         


### PR DESCRIPTION
Added documentation in the wiki for the new Database API. The wiki now describes the methods that make up the API to be used in adding and retrieving moisture_readings records from the database.

Also used underscores at beginning of method names to explicitly define which methods are and are not part of the Database API.